### PR TITLE
参数路由获取参数不正确

### DIFF
--- a/src/RouteDispatcher.php
+++ b/src/RouteDispatcher.php
@@ -49,8 +49,9 @@ class RouteDispatcher
                     $handler = $routeMap[$cnt]['handler'];
                     $params = $routeMap[$cnt]['params'];
 
+                    $i = 0;
                     foreach ($params as $k => $v) {
-                        $params[$k] = $matches[--$cnt];
+                        $params[$k] = $matches[++$i];
                     }
 
                     $return['isFound'] = true;


### PR DESCRIPTION
定义路由为: /user/{id:\d+}/profile,实际请求 /user/10/profile 然后parmas中的id=''而不是id=10